### PR TITLE
Fix compilation reference name

### DIFF
--- a/index.js
+++ b/index.js
@@ -95,7 +95,7 @@ Plugin.prototype.apply = function(compiler) {
       compiler.hooks.compile.tap(plugin, compile);
       compiler.hooks.done.tap(plugin, done);
     } else {
-      compiler.plugin('compilation', compilation);
+      compiler.plugin('compilation', _compilation);
       compiler.plugin('compile', compile);
       compiler.plugin('done', done);
     }


### PR DESCRIPTION
@owais the 0.4.1-beta has an issue with the compilation reference ( missing a leading `_` ) which is causing our builds to fail.    This PR correct that - I've verified it locally.   Thank you again! 